### PR TITLE
Maintain type through __aiter__

### DIFF
--- a/aiochannel/channel.py
+++ b/aiochannel/channel.py
@@ -196,7 +196,7 @@ class Channel(Generic[T]):
         """Returns True if the Channel is marked as closed"""
         return self._close.is_set()
 
-    def __aiter__(self) -> "Channel":
+    def __aiter__(self) -> "Channel[T]":
         """Returns an async iterator (self)"""
         return self
 


### PR DESCRIPTION
This is required to properly infer the type of the object in `async for object in channel`.